### PR TITLE
[#8] feat : 예약 생성 구현하기

### DIFF
--- a/skyscanner/src/main/java/org/third/thirdseminar/common/ApiResponse.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/common/ApiResponse.java
@@ -16,6 +16,7 @@ public class ApiResponse<T> {
 	private final String message;
 	private T data;
 
+
 	public static ApiResponse success(Success success){
 		return new ApiResponse<>(success.getHttpStatusCode(), success.getMessage());
 	}

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/AirReservationController.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/AirReservationController.java
@@ -5,7 +5,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.third.thirdseminar.common.ApiResponse;
 import org.third.thirdseminar.controller.dto.reqeust.AirReservationReqeust;
+import org.third.thirdseminar.controller.dto.reqeust.CreateReservationRequest;
 import org.third.thirdseminar.controller.dto.response.AirReservationResponse;
+import org.third.thirdseminar.controller.dto.response.CreateReservationResponse;
 import org.third.thirdseminar.exception.Success;
 import org.third.thirdseminar.service.ReservationService;
 
@@ -21,7 +23,7 @@ public class AirReservationController {
     }
 
     @PostMapping("/reservation")
-    public ApiResponse<CreateReserverationResponse> createReservertaion(@RequestBody CreateReservationReqeust request){
+    public ApiResponse<CreateReservationResponse> createReservertaion(@RequestBody CreateReservationRequest request){
         return ApiResponse.success(Success.CREATE_RESERVATION_SUCCESS,reservationServcie.createReservation(request));
     }
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/AirReservationController.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/AirReservationController.java
@@ -2,10 +2,7 @@ package org.third.thirdseminar.controller.dto;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.third.thirdseminar.common.ApiResponse;
 import org.third.thirdseminar.controller.dto.reqeust.AirReservationReqeust;
 import org.third.thirdseminar.controller.dto.response.AirReservationResponse;
@@ -18,8 +15,13 @@ import org.third.thirdseminar.service.ReservationService;
 public class AirReservationController {
     private final ReservationService reservationServcie;
 
-    @GetMapping("/reservation")
+    @GetMapping("/reservations")
     public ApiResponse<AirReservationResponse> getReservertaions(@RequestBody AirReservationReqeust request){
         return ApiResponse.success(Success.GET_RESERVATION_SUCCESS,reservationServcie.getReservations(request));
+    }
+
+    @PostMapping("/reservation")
+    public ApiResponse<CreateReserverationResponse> createReservertaion(@RequestBody CreateReservationReqeust request){
+        return ApiResponse.success(Success.CREATE_RESERVATION_SUCCESS,reservationServcie.createReservation(request));
     }
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/reqeust/CreateReservationRequest.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/reqeust/CreateReservationRequest.java
@@ -1,0 +1,12 @@
+package org.third.thirdseminar.controller.dto.reqeust;
+
+import java.util.Date;
+
+public record CreateReservationRequest(
+        Date startDate,
+        Date endDate,
+        Long airId,
+        Long ticketId
+){
+
+}

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/reqeust/CreateReservationRequest.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/reqeust/CreateReservationRequest.java
@@ -5,7 +5,6 @@ import java.util.Date;
 public record CreateReservationRequest(
         Date startDate,
         Date endDate,
-        Long airId,
         Long ticketId
 ){
 

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/CreateReservationResponse.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/CreateReservationResponse.java
@@ -1,15 +1,19 @@
 package org.third.thirdseminar.controller.dto.response;
 
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Date;
 
 public record CreateReservationResponse(
-        LocalTime startDateTime,
-        LocalTime endDateTime,
+        String startDateTime,
+        String endDateTime,
         String price
 ){
-    public static CreateReservationResponse of(LocalTime startDateTime,
-                                               LocalTime endDateTime,
+    public static CreateReservationResponse of(String startDateTime,
+                                               String endDateTime,
                                                String price){
-        return new CreateReservationResponse(startDateTime, endDateTime, price);
+
+        return new CreateReservationResponse(startDateTime,endDateTime, price);
     }
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/CreateReservationResponse.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/CreateReservationResponse.java
@@ -1,0 +1,15 @@
+package org.third.thirdseminar.controller.dto.response;
+
+import java.time.LocalTime;
+
+public record CreateReservationResponse(
+        LocalTime startDateTime,
+        LocalTime endDateTime,
+        String price
+){
+    public static CreateReservationResponse of(LocalTime startDateTime,
+                                               LocalTime endDateTime,
+                                               String price){
+        return new CreateReservationResponse(startDateTime, endDateTime, price);
+    }
+}

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/CreateReservationResponse.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/CreateReservationResponse.java
@@ -1,19 +1,17 @@
 package org.third.thirdseminar.controller.dto.response;
 
-import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.Date;
-
 public record CreateReservationResponse(
         String startDateTime,
         String endDateTime,
+        String companyName,
         String price
+
 ){
     public static CreateReservationResponse of(String startDateTime,
                                                String endDateTime,
+                                               String companyName,
                                                String price){
 
-        return new CreateReservationResponse(startDateTime,endDateTime, price);
+        return new CreateReservationResponse(startDateTime,endDateTime, companyName, price);
     }
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/domain/BaseTimeEntity.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package org.third.thirdseminar.domain;
+
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate  // 현재시각으로 초기화해줌
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+}

--- a/skyscanner/src/main/java/org/third/thirdseminar/domain/ReservationResult.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/domain/ReservationResult.java
@@ -1,0 +1,29 @@
+package org.third.thirdseminar.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReservationResult extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reservationResultId;
+
+    @OneToOne
+    @JoinColumn(name = "ticket_id")
+    private Ticket tickId;
+
+    @OneToOne
+    @JoinColumn(name = "reservation_id")
+    private Reservation reservationId;
+
+    @Builder
+    public ReservationResult(Ticket ticket, Reservation reservation){
+        this.tickId = ticket;
+        this.reservationId = reservation;
+    }
+
+}

--- a/skyscanner/src/main/java/org/third/thirdseminar/exception/Success.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/exception/Success.java
@@ -14,7 +14,8 @@ public enum Success {
 	/**
 	 * 201 CREATED
 	 */
-	CREATE_MEMBER_SUCCESS(HttpStatus.CREATED, "유저 생성 완-벽"),
+	CREATE_RESERVATION_SUCCESS(HttpStatus.CREATED, "예약 사이트로 이동 중 입니다."),
+
 
 	/**
 	 * 200 OK

--- a/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/ReservationJpaRepository.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/ReservationJpaRepository.java
@@ -6,4 +6,5 @@ import org.third.thirdseminar.domain.Reservation;
 import java.util.List;
 
 public interface ReservationJpaRepository extends JpaRepository<Reservation,Long> {
+
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/ReservationResultJpaRepository.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/ReservationResultJpaRepository.java
@@ -1,0 +1,7 @@
+package org.third.thirdseminar.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.third.thirdseminar.domain.ReservationResult;
+
+public interface ReservationResultJpaRepository extends JpaRepository<ReservationResult,Long> {
+}

--- a/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/TickectJpaRepository.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/TickectJpaRepository.java
@@ -9,5 +9,4 @@ import java.util.Optional;
 public interface TickectJpaRepository extends JpaRepository<Ticket,Long> {
     List<Ticket> findByReservationIdOrderByPriceAsc(Long airId);
 
-    Optional<Ticket> findById(Long tickId);
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/TickectJpaRepository.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/TickectJpaRepository.java
@@ -1,11 +1,13 @@
 package org.third.thirdseminar.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.third.thirdseminar.domain.Reservation;
 import org.third.thirdseminar.domain.Ticket;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TickectJpaRepository extends JpaRepository<Ticket,Long> {
     List<Ticket> findByReservationIdOrderByPriceAsc(Long airId);
+
+    Optional<Ticket> findById(Long tickId);
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
@@ -1,5 +1,6 @@
 package org.third.thirdseminar.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,15 +45,15 @@ public class ReservationService {
     }
 
     public CreateReservationResponse createReservation(CreateReservationRequest request){
-        Optional<Ticket> ticket = tickectJpaRepository.findById(request.ticketId());
-        Reservation reservation = ticket.get().getReservation();
+        Ticket ticket = tickectJpaRepository.findById(request.ticketId().longValue()).orElseThrow(()-> new EntityNotFoundException("없는 항공편입니다."));
+        Reservation reservation = ticket.getReservation();
 
 
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String startDateTime = simpleDateFormat.format(reservation.getStartDate()) + " "+ reservation.getStartTime().getStart().format(DateTimeFormatter.ofPattern( "a H:mm" ));
         String endDateTime = simpleDateFormat.format(reservation.getEndDate()) + " " + reservation.getEndTime().getStart().format(DateTimeFormatter.ofPattern( "a H:mm" ));
 
-        return CreateReservationResponse.of(startDateTime, endDateTime, String.format("￦%,d", ticket.get().getPrice()));
+        return CreateReservationResponse.of(startDateTime, endDateTime, ticket.getCompanyName(),String.format("￦%,d", ticket.getPrice()));
 
     }
 

--- a/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
@@ -8,9 +8,11 @@ import org.third.thirdseminar.controller.dto.reqeust.AirReservationReqeust;
 import org.third.thirdseminar.controller.dto.reqeust.CreateReservationRequest;
 import org.third.thirdseminar.controller.dto.response.*;
 import org.third.thirdseminar.domain.Reservation;
+import org.third.thirdseminar.domain.ReservationResult;
 import org.third.thirdseminar.domain.Ticket;
 import org.third.thirdseminar.domain.TimeRange;
 import org.third.thirdseminar.infrastructure.ReservationJpaRepository;
+import org.third.thirdseminar.infrastructure.ReservationResultJpaRepository;
 import org.third.thirdseminar.infrastructure.TickectJpaRepository;
 
 import java.sql.Time;
@@ -30,6 +32,7 @@ public class ReservationService {
 
     private final ReservationJpaRepository reservationJpaRepository;
     private final TickectJpaRepository tickectJpaRepository;
+    private final ReservationResultJpaRepository reservationResultJpaRepository;
     private final DecimalFormat df = new DecimalFormat("###,###");
 
     public AirReservationResponse getReservations(AirReservationReqeust reqeust){
@@ -44,10 +47,15 @@ public class ReservationService {
         return new AirReservationResponse(dateDto, airList);
     }
 
+    @Transactional
     public CreateReservationResponse createReservation(CreateReservationRequest request){
-        Ticket ticket = tickectJpaRepository.findById(request.ticketId().longValue()).orElseThrow(()-> new EntityNotFoundException("없는 항공편입니다."));
+        Ticket ticket = tickectJpaRepository.findById(request.ticketId()).orElseThrow(()-> new EntityNotFoundException("없는 항공편입니다."));
         Reservation reservation = ticket.getReservation();
 
+        ReservationResult reservationResult = reservationResultJpaRepository.save(
+                ReservationResult.builder()
+                        .reservation(reservation)
+                        .ticket(ticket).build());
 
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String startDateTime = simpleDateFormat.format(reservation.getStartDate()) + " "+ reservation.getStartTime().getStart().format(DateTimeFormatter.ofPattern( "a H:mm" ));

--- a/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
@@ -14,6 +14,7 @@ import org.third.thirdseminar.infrastructure.TickectJpaRepository;
 
 import java.sql.Time;
 import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -46,14 +47,19 @@ public class ReservationService {
         Optional<Ticket> ticket = tickectJpaRepository.findById(request.ticketId());
         Reservation reservation = ticket.get().getReservation();
 
-        return CreateReservationResponse.of(reservation.getStartTime().getStart(), reservation.getEndTime().getEnd(), String.format("￦%,d", ticket.get().getPrice()));
+
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        String startDateTime = simpleDateFormat.format(reservation.getStartDate()) + " "+ reservation.getStartTime().getStart().format(DateTimeFormatter.ofPattern( "a H:mm" ));
+        String endDateTime = simpleDateFormat.format(reservation.getEndDate()) + " " + reservation.getEndTime().getStart().format(DateTimeFormatter.ofPattern( "a H:mm" ));
+
+        return CreateReservationResponse.of(startDateTime, endDateTime, String.format("￦%,d", ticket.get().getPrice()));
 
     }
 
     public TimeRangeDto TimeRangeFormat(TimeRange timeRange){
-        String startTime = timeRange.getStart().format( DateTimeFormatter.ofPattern( "HH:mm" ));
-        String endTime = timeRange.getEnd().format( DateTimeFormatter.ofPattern( "HH:mm" ));
-        String during = timeRange.getDuring().format(DateTimeFormatter.ofPattern("HH시간 mm분"));
+        String startTime = timeRange.getStart().format( DateTimeFormatter.ofPattern( "H:mm" ));
+        String endTime = timeRange.getEnd().format( DateTimeFormatter.ofPattern( "H:mm" ));
+        String during = timeRange.getDuring().format(DateTimeFormatter.ofPattern("H시간 mm분"));
 
         return new TimeRangeDto(startTime, endTime, during);
     }

--- a/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
@@ -4,10 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.third.thirdseminar.controller.dto.reqeust.AirReservationReqeust;
-import org.third.thirdseminar.controller.dto.response.AirDto;
-import org.third.thirdseminar.controller.dto.response.AirReservationResponse;
-import org.third.thirdseminar.controller.dto.response.DateDto;
-import org.third.thirdseminar.controller.dto.response.TimeRangeDto;
+import org.third.thirdseminar.controller.dto.reqeust.CreateReservationRequest;
+import org.third.thirdseminar.controller.dto.response.*;
 import org.third.thirdseminar.domain.Reservation;
 import org.third.thirdseminar.domain.Ticket;
 import org.third.thirdseminar.domain.TimeRange;
@@ -21,6 +19,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +40,14 @@ public class ReservationService {
         }
         DateDto dateDto = new DateDto(reqeust.startDate(), reqeust.endDate());
         return new AirReservationResponse(dateDto, airList);
+    }
+
+    public CreateReservationResponse createReservation(CreateReservationRequest request){
+        Optional<Ticket> ticket = tickectJpaRepository.findById(request.ticketId());
+        Reservation reservation = ticket.get().getReservation();
+
+        return CreateReservationResponse.of(reservation.getStartTime().getStart(), reservation.getEndTime().getEnd(), String.format("￦%,d", ticket.get().getPrice()));
+
     }
 
     public TimeRangeDto TimeRangeFormat(TimeRange timeRange){


### PR DESCRIPTION
## 🚩 관련 이슈
- close #8 

## 📋 구현 기능 명세
- [x] 예약 결과 엔티티
[ReservationResult]
``` java
@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor
public class ReservationResult extends BaseTimeEntity {

    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long reservationResultId;

    @OneToOne
    @JoinColumn(name = "ticket_id")
    private Ticket tickId;

    @OneToOne
    @JoinColumn(name = "reservation_id")
    private Reservation reservationId;

    @Builder
    public ReservationResult(Ticket ticket, Reservation reservation){
        this.tickId = ticket;
        this.reservationId = reservation;
    }

}
```
- [x] 예약 생성하기
- [x] 생성된 예약 내용 response

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
request 할때 airId는 필요없는거 같아 제거했습니다.
Response 할때 DateTime 출력 형식을 웹페이지에서 보여주는 형식으로 바꿨습니다.
companyName도 함께 전달해주면 좋을거같아 response에 추가했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
ReservationResult 엔티티 만들긴했는데 저 값만 넣어줘도 괜찮은지?

- 개발하면서 어떤 점이 궁금했는지
"없는 항공권입니다."와 같은 404에러는 어디서 처리해서 어떻게 넘겨줘야하나용?

## 📸 결과물 스크린샷
```json
{
    "code": 201,
    "message": "예약 사이트로 이동 중 입니다.",
    "data": {
        "startDateTime": "2023-11-21 오후 15:22",
        "endDateTime": "2023-11-23 오전 3:02",
        "companyName": "인터파크",
        "price": "￦10,000"
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
-  /air/reservation
