### PR TITLE
[#9] feat : 항공사별 최저가격 조회하기

### DIFF
--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/AirReservationController.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/AirReservationController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import org.third.thirdseminar.common.ApiResponse;
 import org.third.thirdseminar.controller.dto.request.AirReservationRequest;
 import org.third.thirdseminar.controller.dto.request.CreateReservationRequest;
+import org.third.thirdseminar.controller.dto.response.AirMinPriceResponse;
 import org.third.thirdseminar.controller.dto.response.AirReservationResponse;
 import org.third.thirdseminar.controller.dto.response.CreateReservationResponse;
 import org.third.thirdseminar.exception.Success;
@@ -24,5 +25,10 @@ public class AirReservationController {
     @PostMapping("/reservation")
     public ApiResponse<CreateReservationResponse> createReservertaion(@RequestBody CreateReservationRequest request){
         return ApiResponse.success(Success.CREATE_RESERVATION_SUCCESS,reservationServcie.createReservation(request));
+    }
+
+    @GetMapping("/min-prices")
+    public ApiResponse<AirMinPriceResponse> getAirMinPrices(){
+        return ApiResponse.success(Success.GET_AIR_MINPRICE_SUCESS, reservationServcie.getAirMinPrices());
     }
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/AirMinPriceDto.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/AirMinPriceDto.java
@@ -1,0 +1,15 @@
+package org.third.thirdseminar.controller.dto.response;
+
+import java.text.DecimalFormat;
+
+public record AirMinPriceDto (
+        Long airId,
+        String airName,
+        String minPriceString
+){
+    public static AirMinPriceDto of(Long airId, String airName, Long minPriceString) {
+        DecimalFormat df = new DecimalFormat("###,###원부터");
+        return new AirMinPriceDto(airId, airName, df.format(minPriceString));
+    }
+
+}

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/AirMinPriceResponse.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/AirMinPriceResponse.java
@@ -3,7 +3,7 @@ package org.third.thirdseminar.controller.dto.response;
 import java.util.List;
 
 public record AirMinPriceResponse (
-    List<AirMinPriceDto> airMinPriceDtoList
+    List<AirMinPriceDto> airMinPriceDtoList성
 ){
 
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/AirMinPriceResponse.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/AirMinPriceResponse.java
@@ -1,0 +1,9 @@
+package org.third.thirdseminar.controller.dto.response;
+
+import java.util.List;
+
+public record AirMinPriceResponse (
+    List<AirMinPriceDto> airMinPriceDtoList
+){
+
+}

--- a/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/AirMinPriceResponse.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/controller/dto/response/AirMinPriceResponse.java
@@ -3,7 +3,7 @@ package org.third.thirdseminar.controller.dto.response;
 import java.util.List;
 
 public record AirMinPriceResponse (
-    List<AirMinPriceDto> airMinPriceDtoList성
+    List<AirMinPriceDto> airMinPriceDtoList
 ){
 
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/exception/Success.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/exception/Success.java
@@ -20,7 +20,7 @@ public enum Success {
 	/**
 	 * 200 OK
 	 */
-
+	GET_AIR_MINPRICE_SUCESS(HttpStatus.OK, "항공사별 최저가격 조회 성공"),
 	GET_RESERVATION_SUCCESS(HttpStatus.OK, "항공권 페이지 조회 성공"),
 	GET_MAIN_SUCCESS(HttpStatus.OK, "메인 페이지 조회 성공"),
 	GET_TICKET_SUCCESS(HttpStatus.OK, "티켓 선택 페이지 조회 성공"),

--- a/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/TicketJpaRepository.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/infrastructure/TicketJpaRepository.java
@@ -14,5 +14,9 @@ public interface TicketJpaRepository extends JpaRepository<Ticket, Long> {
 
 	List<Ticket> findByReservationIdOrderByPriceAsc(Long airId);
 
+	@Query("SELECT r.air.airId, r.air.airName, MIN(t.price) FROM Ticket t JOIN Reservation r ON t.ticketId = r.id  GROUP BY r.air.airId, r.air.airName ORDER BY r.air.airName")
+	List<Object[]> findMinPricesByAirId();
+
+
 
 }

--- a/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
+++ b/skyscanner/src/main/java/org/third/thirdseminar/service/ReservationService.java
@@ -24,6 +24,7 @@ import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -64,6 +65,19 @@ public class ReservationService {
         return CreateReservationResponse.of(startDateTime, endDateTime, ticket.getCompanyName(),String.format("￦%,d", ticket.getPrice()));
 
     }
+
+    public AirMinPriceResponse getAirMinPrices(){
+        List<AirMinPriceDto> airMinPrices = tickectJpaRepository.findMinPricesByAirId().stream().map(
+                row -> AirMinPriceDto.of(
+                        (Long) row[0],        // airId
+                        (String) row[1],      // airName
+                        (Long) row[2] // minPriceString
+                )).collect(Collectors.toList());
+
+        return new AirMinPriceResponse(airMinPrices);
+
+    }
+
 
     private TimeRangeDto TimeRangeFormat(TimeRange timeRange){
         String startTime = timeRange.getStart().format( DateTimeFormatter.ofPattern( "H:mm" ));


### PR DESCRIPTION
## 🚩 관련 이슈
- close #9

## 📋 구현 기능 명세
- [x] DB에서 항공사별 최저가격 조회해오기
- [x] Dto 변환해서 Response로 보내주기

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
웹페이지에 항공사이름 가나다순으로 정렬되어있어서 이름으로 정렬해서 보내줬습니다.
그러다보니 id 순으로 정렬되진 않았어요!

- 어떤 부분에 리뷰어가 집중해야 하는지

- 개발하면서 어떤 점이 궁금했는지
리팩토링을 어떻게 진행해야할까...

## 📸 결과물 스크린샷
```json
{
    "code": 200,
    "message": "항공사별 최저가격 조회 성공",
    "data": {
        "airMinPriceDtoList": [
            {
                "airId": 1,
                "airName": "대한항공",
                "minPriceString": "100,000원부터"
            },
            {
                "airId": 4,
                "airName": "아시아나항공",
                "minPriceString": "10,000원부터"
            },
            {
                "airId": 5,
                "airName": "야호호",
                "minPriceString": "100,000원부터"
            },
            {
                "airId": 6,
                "airName": "야호호",
                "minPriceString": "100,000원부터"
            },
            {
                "airId": 2,
                "airName": "에어서울",
                "minPriceString": "100,000원부터"
            },
            {
                "airId": 3,
                "airName": "진에어",
                "minPriceString": "1,000원부터"
            }
        ]
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /air/min-prices
